### PR TITLE
added ability to decide the style of the badge. Defaults to flat-square

### DIFF
--- a/main.go
+++ b/main.go
@@ -145,6 +145,12 @@ func HandlerRepoSVG(w http.ResponseWriter, r *http.Request) {
 	if tag == "" {
 		tag = DEFAULT_TAG
 	}
+
+	badgeStyle := r.URL.Query().Get("style")
+	if badgeStyle != "curve" {
+		badgeStyle = "flat-square"
+	}
+
 	obj := repoCover(vars["repo"], tag)
 	cover, _ := strconv.ParseFloat(strings.Replace(obj.Cover, "%", "", -1), 64)
 	var color string
@@ -156,8 +162,8 @@ func HandlerRepoSVG(w http.ResponseWriter, r *http.Request) {
 		color = "red"
 	}
 
-	SHIELDS := "https://img.shields.io/badge/cover.run-%s-%s.svg?style=flat-square"
-	badge := strings.Replace(fmt.Sprintf(SHIELDS, obj.Cover, color), "%", "%25", 1)
+	SHIELDS := "https://img.shields.io/badge/cover.run-%s-%s.svg?style=%s"
+	badge := strings.Replace(fmt.Sprintf(SHIELDS, obj.Cover, color, badgeStyle), "%", "%25", 1)
 
 	http.Redirect(w, r, badge, http.StatusTemporaryRedirect)
 	return


### PR DESCRIPTION
The badge style can be set by adding a query string.
`https://cover.run/go/github.com/bnkamalesh/webgo.svg?tag=golang-1.10&style=curve`. Style will default to `flat-square` as before.