### PR TITLE
Add Go 1.11 as supported language

### DIFF
--- a/main.go
+++ b/main.go
@@ -108,7 +108,8 @@ var (
 // langVersionSupported returns true if the given Go version is supported
 func langVersionSupported(version string) bool {
 	switch version {
-	case "golang-1.10",
+	case "golang-1.11",
+		"golang-1.10",
 		"golang-1.9",
 		"golang-1.8":
 		return true


### PR DESCRIPTION
Should fix #28 

As far as i can tell, the other parts of the software already supported 1.11 and i assume that it has been tested