### PR TITLE
Added go 1.11 to list of supported versions

### DIFF
--- a/main.go
+++ b/main.go
@@ -108,7 +108,8 @@ var (
 // langVersionSupported returns true if the given Go version is supported
 func langVersionSupported(version string) bool {
 	switch version {
-	case "golang-1.10",
+	case "golang-1.11",
+		"golang-1.10",
 		"golang-1.9",
 		"golang-1.8":
 		return true


### PR DESCRIPTION
Although Go 1.11 was added in #22, the list of supported versions was not updated. Because of this, it was not possible to actually run the coverage with go 1.11 as cover.run would always say "Go version not supported". This pr fixes that.